### PR TITLE
Standardizace názvů exportních souborů v Sestavách

### DIFF
--- a/pzi-webapp/app/routes/print-reports/exports/economy/deposit-inquiry-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/deposit-inquiry-export.tsx
@@ -180,7 +180,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-    const fileName = `w_dotazdeponace_${language}_${getXlsFileTimestamp()}.xlsx`;
+    const fileName = `dotaz-k-deponacim_${language}_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/economy/economy-of-movement-summary-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/economy-of-movement-summary-export.tsx
@@ -264,7 +264,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const dateFromFormatted = minDate.replace(/\//g, "");
     const dateToFormatted = maxDate.replace(/\//g, "");
-    const fileName = `w_ucetnisestava_${dateFromFormatted}_${dateToFormatted}_${getXlsFileTimestamp()}.xlsx`;
+    const fileName = `ekonomika-pohybu-podle-trid_${dateFromFormatted}_${dateToFormatted}_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/economy/economy-of-movement-transactions-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/economy-of-movement-transactions-export.tsx
@@ -180,7 +180,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const dateFromFormatted = minDate.replace(/\//g, "");
     const dateToFormatted = maxDate.replace(/\//g, "");
-    const fileName = `w_ucetpohybu_kpr_${dateFromFormatted}_${dateToFormatted}_${getXlsFileTimestamp()}.xlsx`;
+    const fileName = `prehled-pohybu-koupe-prodej_${dateFromFormatted}_${dateToFormatted}_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/economy/feeding-days-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/feeding-days-export.tsx
@@ -121,7 +121,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     
     const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-    const fileName = `krmne_dny_${getXlsFileTimestamp()}.xlsx`;
+    const fileName = `krmne-dny-druhu_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/economy/feeding-days-seized-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/feeding-days-seized-export.tsx
@@ -116,7 +116,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const exportData: SpeciesDto[] = parsedResponse.item || [];
 
-  const fileName = `zabaveno_krmne_dny_${isVertebrate ? 'vertebrate' : 'invertebrate'}_${getXlsFileTimestamp()}.xlsx`;
+  const fileName = `krmne-dny-zabavenych_${isVertebrate ? 'obratlovci' : 'bezobratlci'}_${getXlsFileTimestamp()}.xlsx`;
 
   const dataBlocks = toExportBlocks(exportData, minDate, maxDate);
   const templateBlocks = await prepareTemplateBlocks('statistika__zabaveno_krmne_dny.xlsx', 'zabaveno_krmne_dny');

--- a/pzi-webapp/app/routes/print-reports/exports/economy/region-inventory-all-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/region-inventory-all-export.tsx
@@ -147,13 +147,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const [wb] = await renderPrintExport(templateBlocks, dataBlocks);
     const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-    const fileName = `stavKeDni-po-rajonech_${getXlsFileTimestamp()}`;
+    const fileName = `inventura-po-rajonech_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,
       headers: {
         "Content-Type": "application/vnd.ms-excel",
-        "Content-Disposition": `inline;filename=${fileName}.xlsx`,
+        "Content-Disposition": `inline;filename=${fileName}`,
         "Cache-Control": "no-cache"
       }
     });

--- a/pzi-webapp/app/routes/print-reports/exports/economy/section-inventory-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/economy/section-inventory-export.tsx
@@ -171,13 +171,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const [wb] = await renderPrintExport(templateBlocks, dataBlocks);
     const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-    const fileName = `stavKeDni-usek_${getXlsFileTimestamp()}`;
+    const fileName = `inventura-useku_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,
       headers: {
         "Content-Type": "application/vnd.ms-excel",
-        "Content-Disposition": `inline;filename=${fileName}.xlsx`,
+        "Content-Disposition": `inline;filename=${fileName}`,
         "Cache-Control": "no-cache",
       },
     });

--- a/pzi-webapp/app/routes/print-reports/exports/species/species-history-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/species/species-history-export.tsx
@@ -3,7 +3,7 @@ import { apiCall, processResponse } from "~/.server/api-actions";
 import { BlockData, prepareTemplateBlocks, renderPrintExport } from "~/.server/print-templates/xls-template-exports";
 import { pziConfig } from "~/.server/pzi-config";
 import { requireLoggedInUser } from "~/.server/user-session";
-import { formatToCzechDate } from "~/utils/date-utils";
+import { formatToCzechDate, getXlsFileTimestamp } from "~/utils/date-utils";
 
 export type ExportDataRow = {
   id: number,
@@ -119,7 +119,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=species-history.xlsx`,
+      "Content-Disposition": `inline;filename=historie-druhu_${getXlsFileTimestamp()}.xlsx`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     },
   });

--- a/pzi-webapp/app/routes/print-reports/exports/species/species-in-region-b.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/species/species-in-region-b.tsx
@@ -5,7 +5,7 @@ import { apiCall, processResponse } from "~/.server/api-actions";
 import { BlockData, prepareTemplateBlocks, renderPrintExport } from "~/.server/print-templates/xls-template-exports";
 import { pziConfig } from "~/.server/pzi-config";
 import { requireLoggedInUser } from "~/.server/user-session";
-import { formatToCzechDate } from "~/utils/date-utils";
+import { formatToCzechDate, getXlsFileTimestamp } from "~/utils/date-utils";
 
 export type ExportDataRow = {
     id: number,
@@ -123,7 +123,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return new Response(xlsxBuffer, {
         status: 200,
         headers: {
-            "Content-Disposition": `inline;filename=speciesinregion-owned.xlsx`,
+            "Content-Disposition": `inline;filename=druhy-v-majetku-rajonu_${getXlsFileTimestamp()}.xlsx`,
             "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         },
     });

--- a/pzi-webapp/app/routes/print-reports/exports/species/species-in-zoo-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/species/species-in-zoo-export.tsx
@@ -122,7 +122,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=speciesinzoo-${getXlsFileTimestamp()}.xlsx`,
+      "Content-Disposition": `inline;filename=druh-v-zoo_${getXlsFileTimestamp()}.xlsx`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     },
   });

--- a/pzi-webapp/app/routes/print-reports/exports/specimen/specimen-card-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/specimen/specimen-card-export.tsx
@@ -198,7 +198,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=specimencard_${getXlsFileTimestamp()}.xlsx`,
+      "Content-Disposition": `inline;filename=karta-exemplare_${getXlsFileTimestamp()}.xlsx`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       'Cache-Control': 'no-cache',
     },

--- a/pzi-webapp/app/routes/print-reports/exports/specimen/specimen-descendants-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/specimen/specimen-descendants-export.tsx
@@ -141,7 +141,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=specimen_descendants_${specimenId}_${getXlsFileTimestamp()}.xlsx`,
+      "Content-Disposition": `inline;filename=potomci-exemplare_${specimenId}_${getXlsFileTimestamp()}.xlsx`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       'Cache-Control': 'no-cache',
     },

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/cr-protected-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/cr-protected-export.tsx
@@ -5,6 +5,7 @@ import { apiCall, processResponse } from "~/.server/api-actions";
 import { BlockData, prepareTemplateBlocks, renderPrintExport } from "~/.server/print-templates/xls-template-exports";
 import { pziConfig } from "~/.server/pzi-config";
 import { requireLoggedInUser } from "~/.server/user-session";
+import { getXlsFileTimestamp } from "~/utils/date-utils";
 
 export type SpeciesInfoDto = {
   nameLat: string;
@@ -81,7 +82,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const xlsxBuffer = await wb.xlsx.writeBuffer();
     
-    const fileName = `cr-protected-species.xlsx`;
+    const fileName = `zvlaste-chranene-druhy-cr_${getXlsFileTimestamp()}.xlsx`;
 
     return new Response(xlsxBuffer, {
       status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/full-list-by-zims-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/full-list-by-zims-export.tsx
@@ -3,6 +3,7 @@ import { apiCall, processResponse } from "~/.server/api-actions";
 import { BlockData, prepareTemplateBlocks, renderPrintExport } from "~/.server/print-templates/xls-template-exports";
 import { pziConfig } from "~/.server/pzi-config";
 import { requireLoggedInUser } from "~/.server/user-session";
+import { getXlsFileTimestamp } from "~/utils/date-utils";
 
 type SpecimenDto = {
   accessionNumber?: number;
@@ -48,12 +49,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const [wb] = await renderPrintExport(templateBlocks, dataBlocks);
   const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-  const fileName = `gw_arks_${minZims}_${maxZims}`;
+  const fileName = `kompletni-seznam-zims_${minZims}_${maxZims}_${getXlsFileTimestamp()}.xlsx`;
 
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=${fileName}.xlsx`,
+      "Content-Disposition": `inline;filename=${fileName}`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     },
   });

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/in-zoo-by-region-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/in-zoo-by-region-export.tsx
@@ -164,7 +164,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const [workbook] = await renderPrintExport(templateBlocks, dataBlocks);
   const buffer = await workbook.xlsx.writeBuffer();
   
-  const fileName = `in_zoo_by_region_${vertebrateType}_${getXlsFileTimestamp()}.xlsx`;
+  const fileName = `v-majetku-po-rajonech_${vertebrateType}_${getXlsFileTimestamp()}.xlsx`;
   
   return new Response(buffer, {
     status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/in-zoo-status-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/in-zoo-status-export.tsx
@@ -132,7 +132,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-  const fileName = `inzoostatus_${getXlsFileTimestamp()}.xlsx`;
+  const fileName = `v-majetku_${getXlsFileTimestamp()}.xlsx`;
 
   return new Response(xlsxBuffer, {
     status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/movement-in-zoo-by-species-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/movement-in-zoo-by-species-export.tsx
@@ -104,7 +104,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const dateFromFormatted = minDate.replace(/\//g, "");
   const dateToFormatted = maxDate.replace(/\//g, "");
   const timestamp = getXlsFileTimestamp();
-  const fileName = `w_pohybvzoo_druh_${dateFromFormatted}_${dateToFormatted}_${timestamp}.xlsx`;
+  const fileName = `pohyb-v-zoo-podle-druhu_${dateFromFormatted}_${dateToFormatted}_${timestamp}.xlsx`;
   
   return new Response(xlsxBuffer, {
     status: 200,

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/specimens-for-zims-at-date-range-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/specimens-for-zims-at-date-range-export.tsx
@@ -91,12 +91,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const [wb] = await renderPrintExport(templateBlocks, dataBlocks);
   const xlsxBuffer = await wb.xlsx.writeBuffer();
 
-  const fileName = `gw_ARKS_${getXlsFileTimestamp()}`;
+  const fileName = `seznam-exemplaru-pro-zims_${getXlsFileTimestamp()}.xlsx`;
 
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=${fileName}.xlsx`,
+      "Content-Disposition": `inline;filename=${fileName}`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       "Cache-Control": "no-cache"
     },

--- a/pzi-webapp/app/routes/print-reports/exports/zoology/statistic-births-export.tsx
+++ b/pzi-webapp/app/routes/print-reports/exports/zoology/statistic-births-export.tsx
@@ -92,7 +92,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const dateFromFormatted = minDate.replace(/\//g, "");
   const dateToFormatted = maxDate.replace(/\//g, "");
-  const fileName = `w_dNarozeni_${dateFromFormatted}_${dateToFormatted}-${getXlsFileTimestamp()}.xlsx`;
+  const fileName = `statistika-narozeni_${dateFromFormatted}_${dateToFormatted}_${getXlsFileTimestamp()}.xlsx`;
 
   return new Response(xlsxBuffer, {
     status: 200,


### PR DESCRIPTION
Standardizování 19 exportních souborů s časovými značkami

- Upravené automatické přidávání časových značek ke všem exportům
- Standardizovaný vzorec: [nazev-sestavy]_[casova-znacka].xlsx
- Vždy české názvy (bez angličtiny)
- Vždy s příponou .xlsx
- Srozumitelné i pro starší uživatele

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)