### PR TITLE
Standardize export file naming with timestamps

### DIFF
--- a/pzi-webapp/app/.server/export-xls.ts
+++ b/pzi-webapp/app/.server/export-xls.ts
@@ -5,6 +5,7 @@ import { decodeTableParametersFromRequest } from "~/lib/table-params-encoder-dec
 import { TableSettings } from "~/shared/models";
 import { fetchTableSettings } from './table-settings';
 import { getUserName } from './user-session';
+import { getXlsFileTimestamp } from "~/utils/date-utils";
 
 export function prepareXlsColumnDefinition(
   columnDef: { accessorKey?: string, header: string }[],
@@ -121,10 +122,13 @@ export async function exportToXls<TItem extends MRT_RowData>(
 
   const xlsxBuffer = await workBook.xlsx.writeBuffer();
 
+  const timestamp = getXlsFileTimestamp();
+  const fileName = `${exportName}_${timestamp}`;
+
   return new Response(xlsxBuffer, {
     status: 200,
     headers: {
-      "Content-Disposition": `inline;filename=${exportName}.xlsx`,
+      "Content-Disposition": `inline;filename=${fileName}.xlsx`,
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     },
   });

--- a/pzi-webapp/app/routes/journal/journal-export-xls.tsx
+++ b/pzi-webapp/app/routes/journal/journal-export-xls.tsx
@@ -33,5 +33,5 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const results = await processResponse<PagedResult<JournalEntry>>(response);
   const items = results.item?.items || [];
 
-  return exportToXls(request, items, columnDef, columnVisibility, TABLE_ID, 'export-denik');
+  return exportToXls(request, items, columnDef, columnVisibility, TABLE_ID, 'denik');
 }

--- a/pzi-webapp/app/routes/records/exposition-hierarchy/areas/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/exposition-hierarchy/areas/export-xls.tsx
@@ -20,6 +20,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     columnDef,
     defaultVisibility,
     AREAS_TABLE_ID,
-    "export-oddeleni"
+    "oddeleni"
   );
 }

--- a/pzi-webapp/app/routes/records/exposition-hierarchy/locations/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/exposition-hierarchy/locations/export-xls.tsx
@@ -17,6 +17,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     columnDefVisibility,
     LOCATIONS_TABLE_ID,
-    "export-lokace"
+    "lokace"
   );
 }

--- a/pzi-webapp/app/routes/records/exposition-hierarchy/sets/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/exposition-hierarchy/sets/export-xls.tsx
@@ -21,6 +21,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     defaultVisibility,
     SETS_TABLE_ID,
-    "export-soubory"
+    "soubory"
   );
 }

--- a/pzi-webapp/app/routes/records/exposition-hierarchy/species/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/exposition-hierarchy/species/export-xls.tsx
@@ -25,6 +25,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     columnDefVisibility,
     TABLE_ID,
-    "export-druhy"
+    "druhy"
   );
 }

--- a/pzi-webapp/app/routes/records/exposition-hierarchy/specimens/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/exposition-hierarchy/specimens/export-xls.tsx
@@ -27,6 +27,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     columnDefVisibility,
     SPECIMENS_TABLE_ID,
-    "export-exemplare"
+    "exemplare"
   );
 }

--- a/pzi-webapp/app/routes/records/organization-hierarchy/departments/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/organization-hierarchy/departments/export-xls.tsx
@@ -22,6 +22,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     columnDef,
     defaultVisibility,
     DEPARTMENTS_TABLE_ID,
-    "export-oddeleni"
+    "oddeleni"
   );
 }

--- a/pzi-webapp/app/routes/records/organization-hierarchy/districts/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/organization-hierarchy/districts/export-xls.tsx
@@ -24,6 +24,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     defaultVisibility,
     DISTRICTS_TABLE_ID,
-    "export-useky"
+    "useky"
   );
 }

--- a/pzi-webapp/app/routes/records/organization-hierarchy/locations/locations-export-xls.tsx
+++ b/pzi-webapp/app/routes/records/organization-hierarchy/locations/locations-export-xls.tsx
@@ -17,6 +17,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
         columnDef,         
         columnDefVisibility,  
         LOCATIONS_TABLE_ID,
-        "export-locations"
+        "lokace"
     );
 } 

--- a/pzi-webapp/app/routes/records/organization-hierarchy/species/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/organization-hierarchy/species/export-xls.tsx
@@ -25,6 +25,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     columnDefVisibility,
     TABLE_ID,
-    "export-druhy"
+    "druhy"
   );
 }

--- a/pzi-webapp/app/routes/records/organization-hierarchy/specimens/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/organization-hierarchy/specimens/export-xls.tsx
@@ -27,6 +27,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     columnDefVisibility,
     SPECIMENS_TABLE_ID,
-    "export-exemplare"
+    "exemplare"
   );
 }

--- a/pzi-webapp/app/routes/records/organization-hierarchy/workplaces/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/organization-hierarchy/workplaces/export-xls.tsx
@@ -24,6 +24,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     columnDef,
     defaultVisibility,
     WORKPLACES_TABLE_ID,
-    "export-pracoviste"
+    "pracoviste"
   );
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/classes/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/classes/export-xls.tsx
@@ -11,5 +11,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     `taxonomyclasses?$count=true&$orderby=code&$filter=taxonomyPhylumId eq ${phylumId}`
   );
 
-  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'export-tridy');
+  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'tridy');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/families/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/families/export-xls.tsx
@@ -11,5 +11,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     `taxonomyfamilies?$count=true&$orderby=code&$filter=taxonomyOrderId eq ${parentId}`
   );
 
-  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'export-celede');
+  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'celede');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/genera/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/genera/export-xls.tsx
@@ -11,5 +11,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     `taxonomygenera?$count=true&$orderby=code&$filter=taxonomyFamilyId eq ${parentId}`
   );
 
-  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'export-rody');
+  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'rody');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/orders/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/orders/export-xls.tsx
@@ -11,5 +11,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     `TaxonomyOrders?$count=true&$orderby=code&$filter=taxonomyClassId eq ${classId}`
   );
 
-  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'export-rady');
+  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'rady');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/phyla/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/phyla/export-xls.tsx
@@ -9,5 +9,5 @@ export async function loader({ request }: LoaderFunctionArgs) {
     "TaxonomyPhyla?$count=true&$orderby=code"
   );
 
-  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'export-kmeny');
+  return exportToXls(request, listResult!.items, columnDef, defaultVisibility, TABLE_ID, 'kmeny');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/species/export-documents.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/species/export-documents.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData: TaxonomySpeciesDocumentItemWithFlatRelatedData[] = (listResult?.items || []).map(flattenODataSpeciesDocumentResult);
 
-  return exportToXls(request, itemsWithRelatedData, documentsColumnDef, documentsColumnDefisibility, SPECIES_DOCUMENS_TABLE_ID, 'export-dokumenty-druhu');
+  return exportToXls(request, itemsWithRelatedData, documentsColumnDef, documentsColumnDefisibility, SPECIES_DOCUMENS_TABLE_ID, 'dokumenty-druhu');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/species/export-records.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/species/export-records.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData: TaxononomySpeciesRecordItem[] = (listResult?.items || []).map(flattenODataSpeciesRecordsResult);
 
-  return exportToXls(request, itemsWithRelatedData, recordsColumnDef, recordsColumnDefVisibility, SPECIES_RECORDS_TABLE_ID, 'export-zaznamy-druhu');
+  return exportToXls(request, itemsWithRelatedData, recordsColumnDef, recordsColumnDefVisibility, SPECIES_RECORDS_TABLE_ID, 'zaznamy-druhu');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/species/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/species/export-xls.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData: TaxonomySpeciesItem[] = (listResult?.items || []).map(x => x);
 
-  return exportToXls(request, itemsWithRelatedData, columnDef, columnDefVisibility, TABLE_ID, 'export-druhy');
+  return exportToXls(request, itemsWithRelatedData, columnDef, columnDefVisibility, TABLE_ID, 'druhy');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-cadavers-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-cadavers-xls.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData = (listResult?.items || []).map(flattenCadaver);
 
-  return exportToXls(request, itemsWithRelatedData, cadaversColumnDef, cadaversColumnDefVisibility, SPECIMEN_CADAVERS_TABLE_ID, 'export-kadaver');
+  return exportToXls(request, itemsWithRelatedData, cadaversColumnDef, cadaversColumnDefVisibility, SPECIMEN_CADAVERS_TABLE_ID, 'kadavery');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-documents-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-documents-xls.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData = (listResult?.items || []).map(flattenDocument);
 
-  return exportToXls(request, itemsWithRelatedData, documentsColumnDef, documentsColumnDefVisibility, SPECIMEN_DOCUMENTS_TABLE_ID, 'export-dokumenty');
+  return exportToXls(request, itemsWithRelatedData, documentsColumnDef, documentsColumnDefVisibility, SPECIMEN_DOCUMENTS_TABLE_ID, 'dokumenty');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-markings-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-markings-xls.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData = (listResult?.items || []).map(flattenMarking);
 
-  return exportToXls(request, itemsWithRelatedData, markingsColumnDef, markingsColumnDefVisibility, SPECIMEN_MARKINGS_TABLE_ID, 'export-znaceni');
+  return exportToXls(request, itemsWithRelatedData, markingsColumnDef, markingsColumnDefVisibility, SPECIMEN_MARKINGS_TABLE_ID, 'znaceni');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-movements-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-movements-xls.tsx
@@ -14,5 +14,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const movementsWithRelatedData = (listResult?.items || []).map(flattenODataMovementsResult);
 
-  return exportToXls(request, movementsWithRelatedData, movementsColumnDef, movementsColumnDefVisibility, SPECIMEN_MOVEMENTS_TABLE_ID, 'export-pohyby');
+  return exportToXls(request, movementsWithRelatedData, movementsColumnDef, movementsColumnDefVisibility, SPECIMEN_MOVEMENTS_TABLE_ID, 'pohyby');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-records-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-records-xls.tsx
@@ -13,5 +13,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const itemsWithRelatedData = (listResult?.items || []).map(flattenRecord);
 
-  return exportToXls(request, itemsWithRelatedData, recordsColumnDef, recordsColumnDefVisibility, SPECIMEN_RECORDS_TABLE_ID, 'export-zaznamy');
+  return exportToXls(request, itemsWithRelatedData, recordsColumnDef, recordsColumnDefVisibility, SPECIMEN_RECORDS_TABLE_ID, 'zaznamy');
 }

--- a/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-xls.tsx
+++ b/pzi-webapp/app/routes/records/taxonomy-hierarchy/specimens/export-xls.tsx
@@ -15,5 +15,5 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const specimensWithRelatedData: TaxonomySpecimenItemWithFlatRelatedData[] = (listResult?.items || []).map(flattenODataResult);
 
-  return exportToXls(request, specimensWithRelatedData, columnDef, columnDefVisibility, SPECIMENS_TABLE_ID, 'export-exemplare');
+  return exportToXls(request, specimensWithRelatedData, columnDef, columnDefVisibility, SPECIMENS_TABLE_ID, 'exemplare');
 }


### PR DESCRIPTION
- Modified exportToXls function to automatically add timestamps to all export files
- Removed 'export-' prefix from all export file names for cleaner naming
- Standardized naming pattern: [czech-name]_[timestamp].xlsx
- Updated 26+ export files across taxonomy, organization, and exposition hierarchies
- Export files now have consistent, readable names with timestamps (e.g., 'exemplare_20250919115401.xlsx')
- Names are clear and understandable for all users, including elderly users

🤖 Generated with [Claude Code](https://claude.ai/code)