### PR TITLE
KRITICKÉ: Remove hardcoded database passwords from configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Database Configuration
+# Copy this file to .env and fill in your actual values
+# NEVER commit .env to version control!
+
+# PostgreSQL Database Password
+POSTGRES_PASSWORD=your_secure_password_here
+
+# Connection String Password (for development)
+# Used by .NET applications via environment variable override
+ConnectionStrings__Default=Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=your_secure_password_here
+
+# Auth0 Configuration (if applicable)
+# AUTH0_DOMAIN=your-domain.auth0.com
+# AUTH0_CLIENT_ID=your_client_id
+# AUTH0_CLIENT_SECRET=your_client_secret
+# AUTH0_AUDIENCE=your_api_audience
+
+# API Keys (Development only)
+# Pzi__ApiKeys__0=your_api_key_1
+# Pzi__ApiKeys__1=your_api_key_2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Environment files with secrets
+.env
+.env.local
+.env.*.local
+
 # User-specific files
 *.rsuser
 *.suo

--- a/CI_CD_AUTH0_UPDATES.md
+++ b/CI_CD_AUTH0_UPDATES.md
@@ -203,7 +203,7 @@ services:
     environment:
       - Auth0__Domain=${AUTH0_DOMAIN:-your-tenant.auth0.com}
       - Auth0__Audience=${AUTH0_AUDIENCE:-https://pzi-api}
-      - ConnectionStrings__Default=${PZI_DB_CONNECTION_STRING:-Host=postgresql;Database=pzi;Username=postgres;Password=Xserver@101}
+      - ConnectionStrings__Default=${PZI_DB_CONNECTION_STRING:-Host=postgresql;Database=pzi;Username=postgres;Password=${POSTGRES_PASSWORD}}
       - Pzi__ApiKeys__0=${PZI_API_KEY:-Key1}
     depends_on:
       - postgresql

--- a/MIGRATION_TO_POSTGRESQL.md
+++ b/MIGRATION_TO_POSTGRESQL.md
@@ -69,10 +69,12 @@ The PZI (Prague Zoo Information System) project has been successfully migrated f
 ```json
 {
   "ConnectionStrings": {
-    "Default": "Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=Xserver@101"
+    "Default": "Host=localhost;Port=5432;Database=pzi;Username=postgres"
   }
 }
 ```
+
+**Note**: Password should be provided via environment variables or User Secrets. See [SECURITY_SECRETS.md](SECURITY_SECRETS.md) for details.
 
 #### DbContext Configuration (Program.cs)
 **Before:**
@@ -138,7 +140,7 @@ services:
     environment:
       POSTGRES_DB: pzi
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: Xserver@101
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
     ports:
       - "5432:5432"
     volumes:

--- a/SECURITY_SECRETS.md
+++ b/SECURITY_SECRETS.md
@@ -1,0 +1,204 @@
+# Security & Secrets Management
+
+## Overview
+This document describes how to securely manage sensitive configuration data in the PZI application.
+
+## 🔐 Never Commit Secrets
+**CRITICAL**: Never commit passwords, API keys, or other sensitive data to version control!
+
+## Development Environment
+
+### Method 1: Environment Variables (Recommended)
+
+1. **Copy the example file**:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **Edit `.env` with your actual credentials**:
+   ```bash
+   # Database password
+   POSTGRES_PASSWORD=your_actual_password
+
+   # Connection string (overrides appsettings)
+   ConnectionStrings__Default=Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=your_actual_password
+   ```
+
+3. **Load environment variables**:
+   ```bash
+   # Linux/macOS
+   source .env
+
+   # Or use docker-compose (automatically loads .env)
+   docker-compose up
+   ```
+
+### Method 2: .NET User Secrets (Development Only)
+
+For local .NET development, use User Secrets:
+
+```bash
+cd pzi-api/PziApi
+
+# Set connection string
+dotnet user-secrets set "ConnectionStrings:Default" "Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=your_password"
+
+# Set API keys
+dotnet user-secrets set "Pzi:ApiKeys:0" "your_api_key_1"
+dotnet user-secrets set "Pzi:ApiKeys:1" "your_api_key_2"
+
+# Set Auth0 configuration
+dotnet user-secrets set "Auth0:Domain" "your-domain.auth0.com"
+dotnet user-secrets set "Auth0:ClientId" "your_client_id"
+dotnet user-secrets set "Auth0:ClientSecret" "your_client_secret"
+```
+
+User secrets are stored locally at:
+- **Windows**: `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json`
+- **Linux/macOS**: `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json`
+
+## Production Environment
+
+### Azure Key Vault (Recommended)
+
+1. **Create Azure Key Vault**:
+   ```bash
+   az keyvault create --name pzi-keyvault --resource-group pzi-rg --location westeurope
+   ```
+
+2. **Store secrets**:
+   ```bash
+   az keyvault secret set --vault-name pzi-keyvault --name "ConnectionStrings--Default" --value "your_connection_string"
+   az keyvault secret set --vault-name pzi-keyvault --name "Auth0--ClientSecret" --value "your_client_secret"
+   ```
+
+3. **Configure App Service**:
+   - Enable Managed Identity for App Service
+   - Grant Key Vault access to Managed Identity
+   - Reference secrets in configuration:
+     ```json
+     {
+       "ConnectionStrings": {
+         "Default": "@Microsoft.KeyVault(VaultName=pzi-keyvault;SecretName=ConnectionStrings--Default)"
+       }
+     }
+     ```
+
+### Environment Variables (Alternative)
+
+Configure in Azure App Service → Configuration → Application Settings:
+
+```
+ConnectionStrings__Default = Host=prod-db.postgres.database.azure.com;Database=pzi;Username=admin;Password=***
+Auth0__Domain = your-domain.auth0.com
+Auth0__ClientId = ***
+Auth0__ClientSecret = ***
+POSTGRES_PASSWORD = ***
+```
+
+## Docker Deployment
+
+### Using .env file
+```bash
+# Create .env file (not committed to git)
+cat > .env << EOF
+POSTGRES_PASSWORD=secure_password_here
+ConnectionStrings__Default=Host=postgresql;Database=pzi;Username=postgres;Password=secure_password_here
+EOF
+
+# Run with docker-compose
+docker-compose up -d
+```
+
+### Using Docker Secrets (Swarm/K8s)
+```bash
+# Create secrets
+echo "my_secure_password" | docker secret create postgres_password -
+
+# Reference in docker-compose.yml
+secrets:
+  postgres_password:
+    external: true
+```
+
+## CI/CD Pipeline
+
+### GitHub Actions Secrets
+
+Store sensitive data in GitHub repository secrets:
+
+1. Go to: Repository → Settings → Secrets and variables → Actions
+2. Add secrets:
+   - `POSTGRES_PASSWORD`
+   - `AUTH0_CLIENT_SECRET`
+   - `ACR_USER`
+   - `ACR_PASSWORD`
+
+Reference in workflow:
+```yaml
+env:
+  ConnectionStrings__Default: ${{ secrets.DB_CONNECTION_STRING }}
+  Auth0__ClientSecret: ${{ secrets.AUTH0_CLIENT_SECRET }}
+```
+
+## Configuration Priority
+
+.NET configuration sources are loaded in this order (later sources override earlier):
+
+1. `appsettings.json`
+2. `appsettings.{Environment}.json`
+3. User Secrets (Development only)
+4. Environment Variables
+5. Command-line arguments
+
+**Best Practice**: Store default/non-sensitive values in `appsettings.json`, override with environment variables or User Secrets.
+
+## Security Checklist
+
+- [ ] `.env` file is in `.gitignore`
+- [ ] No hardcoded passwords in `appsettings.json` or `appsettings.Development.json`
+- [ ] Production secrets stored in Azure Key Vault or secure environment variables
+- [ ] User Secrets configured for local development
+- [ ] CI/CD secrets configured in GitHub Actions
+- [ ] Connection strings use environment variable overrides
+- [ ] Regular secret rotation policy in place
+
+## Troubleshooting
+
+### "Connection failed" errors
+
+1. **Check environment variables are loaded**:
+   ```bash
+   echo $ConnectionStrings__Default
+   ```
+
+2. **Verify .NET reads the connection string**:
+   ```bash
+   dotnet run --project pzi-api/PziApi
+   # Check logs for connection string source
+   ```
+
+3. **Test PostgreSQL connection**:
+   ```bash
+   psql "Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=your_password"
+   ```
+
+### User Secrets not working
+
+1. **Verify user secrets are initialized**:
+   ```bash
+   dotnet user-secrets list --project pzi-api/PziApi
+   ```
+
+2. **Check csproj has UserSecretsId**:
+   ```xml
+   <PropertyGroup>
+     <UserSecretsId>your-unique-id</UserSecretsId>
+   </PropertyGroup>
+   ```
+
+## References
+
+- [.NET User Secrets](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets)
+- [Azure Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/)
+- [Environment Variables in .NET](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       POSTGRES_DB: pzi
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: Xserver@101
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
     ports:
       - "5432:5432"
     volumes:

--- a/pzi-api/PziApi/appsettings.Development.json
+++ b/pzi-api/PziApi/appsettings.Development.json
@@ -28,6 +28,6 @@
     }
   },
   "ConnectionStrings": {
-    "Default": "Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=Xserver@101"
+    "Default": "Host=localhost;Port=5432;Database=pzi;Username=postgres"
   }
 }

--- a/pzi-api/README.md
+++ b/pzi-api/README.md
@@ -6,9 +6,40 @@ API project that powers PZI backend.
 
 ## Database connection in local environment
 
-- To configure database connection for local development, it is preferred to use `user-secrets` provided by .net framework. They can be set from Vistual Stuio UI or from command line:
-  - `dotnet user-secrets set "ConnectionStrings:Default" "<<VALUE>>"`
-- We generally use shared instance of database (managing imported data is quite difficult to have per-user DBs), value for connection string can be provided on-demand.
+⚠️ **SECURITY**: Never commit database passwords to version control!
+
+### Option 1: User Secrets (Recommended for local development)
+
+Configure database connection using .NET User Secrets:
+
+```bash
+dotnet user-secrets set "ConnectionStrings:Default" "Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=YOUR_PASSWORD"
+```
+
+User secrets are stored locally and never committed to git.
+
+### Option 2: Environment Variables
+
+Set environment variable before running the application:
+
+```bash
+# Linux/macOS
+export ConnectionStrings__Default="Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=YOUR_PASSWORD"
+
+# Windows PowerShell
+$env:ConnectionStrings__Default="Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=YOUR_PASSWORD"
+```
+
+### Option 3: .env file (for Docker)
+
+Copy `.env.example` to `.env` in the project root and set your password:
+
+```bash
+cp ../.env.example ../.env
+# Edit .env and set POSTGRES_PASSWORD
+```
+
+📖 For detailed security and secrets management, see [SECURITY_SECRETS.md](../SECURITY_SECRETS.md)
 
 ## Configuration values for container
 


### PR DESCRIPTION
## Summary
🔒 **CRITICAL SECURITY FIX**: Removed hardcoded database passwords from configuration files to address Issue #19.

## Problem
Database passwords were hardcoded in multiple configuration files:
- `pzi-api/PziApi/appsettings.Development.json` - Line 31
- `docker-compose.yml` - Line 7
- Various documentation files

This exposed sensitive credentials to anyone with repository access, creating a severe security vulnerability.

## Solution

### 1. Configuration Files Updated
- ✅ Removed hardcoded password from `appsettings.Development.json`
- ✅ Updated `docker-compose.yml` to use environment variable `${POSTGRES_PASSWORD:-changeme}`
- ✅ Updated documentation files to remove hardcoded examples

### 2. Security Infrastructure Added
- ✅ Created `.env.example` template for local development
- ✅ Added `.env*` files to `.gitignore`
- ✅ Created comprehensive `SECURITY_SECRETS.md` documentation
- ✅ Updated `pzi-api/README.md` with secure configuration methods

### 3. Multiple Secure Configuration Options

**Development:**
- User Secrets (recommended): `dotnet user-secrets set "ConnectionStrings:Default" "..."`
- Environment variables via `.env` file
- Environment variables export

**Production:**
- Azure Key Vault integration
- App Service environment variables
- Docker secrets

## Security Improvements
- 🔐 No passwords in version control
- 📝 Clear documentation for secure configuration
- 🛡️ Multiple layers of secret management
- ✅ Works across dev/staging/production environments

## Test Plan
- [x] Verified `.env` is in `.gitignore`
- [x] Confirmed User Secrets ID exists in `.csproj`
- [x] Validated docker-compose uses environment variable
- [x] Documentation updated with security warnings
- [x] All hardcoded passwords removed from tracked files

## Migration Steps for Developers

1. **Create `.env` file** (not tracked in git):
   ```bash
   cp .env.example .env
   # Edit .env and set your password
   ```

2. **Or use User Secrets**:
   ```bash
   dotnet user-secrets set "ConnectionStrings:Default" "Host=localhost;Port=5432;Database=pzi;Username=postgres;Password=YOUR_PASSWORD"
   ```

3. **Start services**:
   ```bash
   docker-compose up -d
   ```

## References
- Closes #19
- Documentation: [SECURITY_SECRETS.md](../blob/claude/issue-19-20251003-1315/SECURITY_SECRETS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)